### PR TITLE
fix: 엔티티 <-> DTO 간 LocalDateTime <-> LocalDate 변환 오류 수정

### DIFF
--- a/qrust-domain/src/main/java/com/qrust/qrcode/dto/response/QrCodeListResponseDto.java
+++ b/qrust-domain/src/main/java/com/qrust/qrcode/dto/response/QrCodeListResponseDto.java
@@ -1,15 +1,13 @@
 package com.qrust.qrcode.dto.response;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record QrCodeListResponseDto (Long qrCodeId, String qrCodeImageUrl, String title, LocalDate createdAt, String url) {
 
-    public QrCodeListResponseDto(Long qrCodeId, String qrCodeImageUrl, String title, LocalDate createdAt, String url) {
-        this.qrCodeId = qrCodeId;
-        this.qrCodeImageUrl = qrCodeImageUrl;
-        this.title = title;
-        this.createdAt = createdAt;
-        this.url = url;
+    public QrCodeListResponseDto(Long qrCodeId, String qrCodeImageUrl, String title, LocalDateTime createdAt, String url) {
+        this(qrCodeId, qrCodeImageUrl, title, createdAt.toLocalDate(), url);
+
     }
 
 }


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #38

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
querydsl로 QrCode 엔티티를 가져오고, 엔티티의 생성 시각을 DTO의 생성 시각으로 변환할 때 LocalDateTime -> LocalDate 과정에서 발생하는 생성자 오류 수정
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.
![image](https://github.com/user-attachments/assets/711fce76-b47f-4703-9970-793dd379d713)

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 생성자에서 날짜 파라미터 타입이 LocalDate에서 LocalDateTime으로 변경되었습니다.  
  - 내부적으로 LocalDateTime이 LocalDate로 변환되어 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->