### PR TITLE
feat: 신고 게시판 api 생성

### DIFF
--- a/qrust-api/src/main/java/com/qrust/annotation/RoleOnly.java
+++ b/qrust-api/src/main/java/com/qrust/annotation/RoleOnly.java
@@ -1,0 +1,12 @@
+package com.qrust.annotation;
+
+import com.qrust.user.domain.entity.vo.UserRole;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RoleOnly {
+    UserRole[] value();
+}

--- a/qrust-api/src/main/java/com/qrust/annotation/RoleOnlyAspect.java
+++ b/qrust-api/src/main/java/com/qrust/annotation/RoleOnlyAspect.java
@@ -1,0 +1,46 @@
+package com.qrust.annotation;
+
+import static com.qrust.exception.auth.ErrorMessages.INVALID_TOKEN;
+import static com.qrust.exception.error.ErrorCode.INVALID_INPUT_VALUE;
+import static com.qrust.exception.user.ErrorMessages.USER_NOT_AUTHORIZED;
+
+import com.qrust.exception.CustomException;
+import com.qrust.user.domain.entity.vo.UserRole;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class RoleOnlyAspect {
+
+    @Before("@within(roleOnly) || @annotation(roleOnly)")
+    public void checkRole(RoleOnly roleOnly) {
+        UserRole actualRole = getCurrentRole();
+        boolean hasRequiredRole = Arrays.stream(roleOnly.value())
+                .anyMatch(required -> UserRole.isRoleIncluded(actualRole, required));
+
+        if (!hasRequiredRole) {
+            throw new CustomException(INVALID_INPUT_VALUE, USER_NOT_AUTHORIZED);
+        }
+    }
+
+    private UserRole getCurrentRole() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new CustomException(INVALID_INPUT_VALUE, INVALID_TOKEN);
+        }
+
+        String authority = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(granted -> granted.getAuthority())
+                .orElseThrow(() -> new CustomException(INVALID_INPUT_VALUE, USER_NOT_AUTHORIZED));
+
+        return UserRole.fromStringOrThrow(authority.replace("ROLE_", ""));
+    }
+}

--- a/qrust-api/src/main/java/com/qrust/auth/controller/AuthController.java
+++ b/qrust-api/src/main/java/com/qrust/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.qrust.dto.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,13 +17,13 @@ public class AuthController implements AuthControllerSpec {
     private final AuthFacade authFacade;
 
     @Override
-    public ApiResponse<Boolean> signup(SignUpRequest request) {
+    public ApiResponse<Boolean> signup(@RequestBody SignUpRequest request) {
         authFacade.signUp(request);
         return ApiResponse.ok(true);
     }
 
     @Override
-    public ApiResponse<Boolean> login(LoginRequest request, HttpServletResponse response) {
+    public ApiResponse<Boolean> login(@RequestBody LoginRequest request, HttpServletResponse response) {
         authFacade.login(request, response);
         return ApiResponse.ok(true);
     }

--- a/qrust-api/src/main/java/com/qrust/auth/swagger/AuthControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/auth/swagger/AuthControllerSpec.java
@@ -20,14 +20,14 @@ public interface AuthControllerSpec {
     @PostMapping("/signup")
     ApiResponse<Boolean> signup(
             @Parameter(description = "회원가입 정보")
-            @RequestBody SignUpRequest request
+            SignUpRequest request
     );
 
     @Operation(summary = "로그인", description = "로그인")
     @PostMapping("/login")
     ApiResponse<Boolean> login(
             @Parameter(description = "로그인 정보")
-            @RequestBody LoginRequest request,
+            LoginRequest request,
             HttpServletResponse response
     );
 

--- a/qrust-api/src/main/java/com/qrust/recognize/controller/AiModelController.java
+++ b/qrust-api/src/main/java/com/qrust/recognize/controller/AiModelController.java
@@ -4,6 +4,7 @@ import com.qrust.dto.ApiResponse;
 import com.qrust.external.ai.application.AiModelUrlVerifyService;
 import com.qrust.recognize.swagger.AiModelControllerSpec;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,7 +14,7 @@ public class AiModelController implements AiModelControllerSpec {
     private final AiModelUrlVerifyService aiModelUrlVerifyService;
 
     @Override
-    public ApiResponse<Boolean> checkUrlByAiModel(String url) {
+    public ApiResponse<Boolean> checkUrlByAiModel(@RequestParam String url) {
         int result = aiModelUrlVerifyService.verifyUrl(url);
         boolean isMalicious = result == 1;
         return ApiResponse.ok(isMalicious);

--- a/qrust-api/src/main/java/com/qrust/recognize/controller/GoogleSafeBrowsingController.java
+++ b/qrust-api/src/main/java/com/qrust/recognize/controller/GoogleSafeBrowsingController.java
@@ -4,6 +4,7 @@ import com.qrust.dto.ApiResponse;
 import com.qrust.external.google.application.GoogleSafeBrowsingService;
 import com.qrust.recognize.swagger.GoogleSafeBrowsingControllerSpec;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,7 +14,7 @@ public class GoogleSafeBrowsingController implements GoogleSafeBrowsingControlle
     private final GoogleSafeBrowsingService safeBrowsingService;
 
     @Override
-    public ApiResponse<Boolean> checkUrl(String url) {
+    public ApiResponse<Boolean> checkUrl(@RequestParam String url) {
         return ApiResponse.ok(safeBrowsingService.isUrlDangerous(url));
     }
 }

--- a/qrust-api/src/main/java/com/qrust/recognize/swagger/AiModelControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/recognize/swagger/AiModelControllerSpec.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "QR Recognize Service", description = "AI 기반 URL 위험 탐지")
 @RequestMapping("/api/v1/recognize")
@@ -16,6 +15,6 @@ public interface AiModelControllerSpec {
     @PostMapping("/ai-model")
     ApiResponse<Boolean> checkUrlByAiModel(
             @Parameter(description = "확인할 URL", example = "http://phishing-site.com")
-            @RequestParam String url
+            String url
     );
 }

--- a/qrust-api/src/main/java/com/qrust/recognize/swagger/GoogleSafeBrowsingControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/recognize/swagger/GoogleSafeBrowsingControllerSpec.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "QR Recognize Service", description = "안전한 QR 인식")
 @RequestMapping("/api/v1/recognize")
@@ -16,6 +15,6 @@ public interface GoogleSafeBrowsingControllerSpec {
     @PostMapping("/blacklist")
     ApiResponse<Boolean> checkUrl(
             @Parameter(description = "확인할 URL", example = "http://example.com")
-            @RequestParam String url
+            String url
     );
 }

--- a/qrust-api/src/main/java/com/qrust/report/controller/ReportAdminController.java
+++ b/qrust-api/src/main/java/com/qrust/report/controller/ReportAdminController.java
@@ -4,6 +4,7 @@ import com.qrust.dto.ApiResponse;
 import com.qrust.report.application.ReportFacade;
 import com.qrust.report.swagger.ReportAdminControllerSpec;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,13 +14,13 @@ public class ReportAdminController implements ReportAdminControllerSpec {
     private final ReportFacade reportFacade;
 
     @Override
-    public ApiResponse<Boolean> approveReport(Long reportId) {
+    public ApiResponse<Boolean> approveReport(@PathVariable Long reportId) {
         reportFacade.approveReport(reportId);
         return ApiResponse.ok(true);
     }
 
     @Override
-    public ApiResponse<Boolean> rejectReport(Long reportId) {
+    public ApiResponse<Boolean> rejectReport(@PathVariable Long reportId) {
         reportFacade.rejectReport(reportId);
         return ApiResponse.ok(true);
     }

--- a/qrust-api/src/main/java/com/qrust/report/controller/ReportAdminController.java
+++ b/qrust-api/src/main/java/com/qrust/report/controller/ReportAdminController.java
@@ -1,0 +1,4 @@
+package com.qrust.report.controller;
+
+public class ReportAdminController {
+}

--- a/qrust-api/src/main/java/com/qrust/report/controller/ReportAdminController.java
+++ b/qrust-api/src/main/java/com/qrust/report/controller/ReportAdminController.java
@@ -1,4 +1,26 @@
 package com.qrust.report.controller;
 
-public class ReportAdminController {
+import com.qrust.dto.ApiResponse;
+import com.qrust.report.application.ReportFacade;
+import com.qrust.report.swagger.ReportAdminControllerSpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportAdminController implements ReportAdminControllerSpec {
+
+    private final ReportFacade reportFacade;
+
+    @Override
+    public ApiResponse<Boolean> approveReport(Long reportId) {
+        reportFacade.approveReport(reportId);
+        return ApiResponse.ok(true);
+    }
+
+    @Override
+    public ApiResponse<Boolean> rejectReport(Long reportId) {
+        reportFacade.rejectReport(reportId);
+        return ApiResponse.ok(true);
+    }
 }

--- a/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
+++ b/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
@@ -3,6 +3,7 @@ package com.qrust.report.controller;
 import com.qrust.annotation.user.LoginUser;
 import com.qrust.dto.ApiResponse;
 import com.qrust.report.application.ReportFacade;
+import com.qrust.report.dto.PhishingReportDetailResponse;
 import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
 import com.qrust.report.swagger.ReportControllerSpec;
@@ -25,5 +26,10 @@ public class ReportController implements ReportControllerSpec {
     @Override
     public ApiResponse<List<PhishingReportResponse>> getMyReports(@LoginUser Long userId) {
         return ApiResponse.ok(reportFacade.getMyReports(userId));
+    }
+
+    @Override
+    public ApiResponse<PhishingReportDetailResponse> getReportDetail(Long reportId, Long userId) {
+        return ApiResponse.ok(reportFacade.getReportDetail(reportId, userId));
     }
 }

--- a/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
+++ b/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
@@ -9,6 +9,8 @@ import com.qrust.report.dto.PhishingReportUpsertRequest;
 import com.qrust.report.swagger.ReportControllerSpec;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,7 +20,8 @@ public class ReportController implements ReportControllerSpec {
     private final ReportFacade reportFacade;
 
     @Override
-    public ApiResponse<Boolean> registerReport(PhishingReportUpsertRequest request, Long userId) {
+    public ApiResponse<Boolean> registerReport(@RequestBody PhishingReportUpsertRequest request,
+                                               @LoginUser Long userId) {
         reportFacade.registerReport(request, userId);
         return ApiResponse.ok(true);
     }
@@ -29,7 +32,8 @@ public class ReportController implements ReportControllerSpec {
     }
 
     @Override
-    public ApiResponse<PhishingReportDetailResponse> getReportDetail(Long reportId, Long userId) {
+    public ApiResponse<PhishingReportDetailResponse> getReportDetail(@PathVariable Long reportId,
+                                                                     @LoginUser Long userId) {
         return ApiResponse.ok(reportFacade.getReportDetail(reportId, userId));
     }
 }

--- a/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
+++ b/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
@@ -1,0 +1,21 @@
+package com.qrust.report.controller;
+
+import com.qrust.dto.ApiResponse;
+import com.qrust.report.application.ReportFacade;
+import com.qrust.report.dto.PhishingReportUpsertRequest;
+import com.qrust.report.swagger.ReportControllerSpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportController implements ReportControllerSpec {
+
+    private final ReportFacade reportFacade;
+
+    @Override
+    public ApiResponse<Boolean> registerReport(PhishingReportUpsertRequest request, Long userId) {
+        reportFacade.registerReport(request, userId);
+        return ApiResponse.ok(true);
+    }
+}

--- a/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
+++ b/qrust-api/src/main/java/com/qrust/report/controller/ReportController.java
@@ -1,9 +1,12 @@
 package com.qrust.report.controller;
 
+import com.qrust.annotation.user.LoginUser;
 import com.qrust.dto.ApiResponse;
 import com.qrust.report.application.ReportFacade;
+import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
 import com.qrust.report.swagger.ReportControllerSpec;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,5 +20,10 @@ public class ReportController implements ReportControllerSpec {
     public ApiResponse<Boolean> registerReport(PhishingReportUpsertRequest request, Long userId) {
         reportFacade.registerReport(request, userId);
         return ApiResponse.ok(true);
+    }
+
+    @Override
+    public ApiResponse<List<PhishingReportResponse>> getMyReports(@LoginUser Long userId) {
+        return ApiResponse.ok(reportFacade.getMyReports(userId));
     }
 }

--- a/qrust-api/src/main/java/com/qrust/report/swagger/ReportAdminControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/report/swagger/ReportAdminControllerSpec.java
@@ -5,7 +5,6 @@ import com.qrust.dto.ApiResponse;
 import com.qrust.user.domain.entity.vo.UserRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -16,9 +15,9 @@ public interface ReportAdminControllerSpec {
 
     @Operation(summary = "신고 승인", description = "PENDING 상태의 신고를 승인 처리합니다.")
     @PostMapping("/{reportId}/approve")
-    ApiResponse<Boolean> approveReport(@PathVariable Long reportId);
+    ApiResponse<Boolean> approveReport(Long reportId);
 
     @Operation(summary = "신고 거부", description = "PENDING 상태의 신고를 거부합니다.")
     @PostMapping("/{reportId}/reject")
-    ApiResponse<Boolean> rejectReport(@PathVariable Long reportId);
+    ApiResponse<Boolean> rejectReport(Long reportId);
 }

--- a/qrust-api/src/main/java/com/qrust/report/swagger/ReportAdminControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/report/swagger/ReportAdminControllerSpec.java
@@ -1,0 +1,24 @@
+package com.qrust.report.swagger;
+
+import com.qrust.annotation.RoleOnly;
+import com.qrust.dto.ApiResponse;
+import com.qrust.user.domain.entity.vo.UserRole;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "QRust ADMIN REPORT", description = "관리자 - 피싱 신고 관리 API")
+@RequestMapping("/api/v1/admin/report")
+@RoleOnly(UserRole.ADMIN)
+public interface ReportAdminControllerSpec {
+
+    @Operation(summary = "신고 승인", description = "PENDING 상태의 신고를 승인 처리합니다.")
+    @PostMapping("/{reportId}/approve")
+    ApiResponse<Boolean> approveReport(@PathVariable Long reportId);
+
+    @Operation(summary = "신고 거부", description = "PENDING 상태의 신고를 거부합니다.")
+    @PostMapping("/{reportId}/reject")
+    ApiResponse<Boolean> rejectReport(@PathVariable Long reportId);
+}

--- a/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
@@ -1,6 +1,5 @@
 package com.qrust.report.swagger;
 
-import com.qrust.annotation.user.LoginUser;
 import com.qrust.dto.ApiResponse;
 import com.qrust.report.dto.PhishingReportDetailResponse;
 import com.qrust.report.dto.PhishingReportResponse;
@@ -10,9 +9,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "QRust REPORT", description = "피싱 신고 API")
@@ -22,18 +19,18 @@ public interface ReportControllerSpec {
     @Operation(summary = "피싱 신고 등록", description = "피싱 사이트 신고를 등록합니다.")
     @PostMapping("/register")
     ApiResponse<Boolean> registerReport(
-            @Parameter(description = "피싱 신고 정보") @RequestBody PhishingReportUpsertRequest request,
-            @LoginUser Long userId
+            @Parameter(description = "피싱 신고 정보") PhishingReportUpsertRequest request,
+            Long userId
     );
 
     @Operation(summary = "내 신고 목록", description = "로그인한 사용자의 신고 목록을 조회합니다.")
     @GetMapping("/my")
-    ApiResponse<List<PhishingReportResponse>> getMyReports(@LoginUser Long userId);
+    ApiResponse<List<PhishingReportResponse>> getMyReports(Long userId);
 
     @Operation(summary = "신고 상세 조회", description = "사용자의 신고 상세 정보를 조회합니다.")
     @GetMapping("/{reportId}")
     ApiResponse<PhishingReportDetailResponse> getReportDetail(
-            @PathVariable Long reportId,
-            @LoginUser Long userId
+            Long reportId,
+            Long userId
     );
 }

--- a/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
@@ -2,6 +2,7 @@ package com.qrust.report.swagger;
 
 import com.qrust.annotation.user.LoginUser;
 import com.qrust.dto.ApiResponse;
+import com.qrust.report.dto.PhishingReportDetailResponse;
 import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,4 +29,11 @@ public interface ReportControllerSpec {
     @Operation(summary = "내 신고 목록", description = "로그인한 사용자의 신고 목록을 조회합니다.")
     @GetMapping("/my")
     ApiResponse<List<PhishingReportResponse>> getMyReports(@LoginUser Long userId);
+
+    @Operation(summary = "신고 상세 조회", description = "사용자의 신고 상세 정보를 조회합니다.")
+    @GetMapping("/{reportId}")
+    ApiResponse<PhishingReportDetailResponse> getReportDetail(
+            @PathVariable Long reportId,
+            @LoginUser Long userId
+    );
 }

--- a/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
@@ -1,0 +1,23 @@
+package com.qrust.report.swagger;
+
+import com.qrust.annotation.user.LoginUser;
+import com.qrust.dto.ApiResponse;
+import com.qrust.report.dto.PhishingReportUpsertRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "QRust REPORT", description = "피싱 신고 API")
+@RequestMapping("/api/v1/report")
+public interface ReportControllerSpec {
+
+    @Operation(summary = "피싱 신고 등록", description = "피싱 사이트 신고를 등록합니다.")
+    @PostMapping("/register")
+    ApiResponse<Boolean> registerReport(
+            @Parameter(description = "피싱 신고 정보") @RequestBody PhishingReportUpsertRequest request,
+            @Parameter(description = "사용자 ID") @LoginUser Long userId
+    );
+}

--- a/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
@@ -2,10 +2,13 @@ package com.qrust.report.swagger;
 
 import com.qrust.annotation.user.LoginUser;
 import com.qrust.dto.ApiResponse;
+import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,4 +23,8 @@ public interface ReportControllerSpec {
             @Parameter(description = "피싱 신고 정보") @RequestBody PhishingReportUpsertRequest request,
             @LoginUser Long userId
     );
+
+    @Operation(summary = "내 신고 목록", description = "로그인한 사용자의 신고 목록을 조회합니다.")
+    @GetMapping("/my")
+    ApiResponse<List<PhishingReportResponse>> getMyReports(@LoginUser Long userId);
 }

--- a/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
+++ b/qrust-api/src/main/java/com/qrust/report/swagger/ReportControllerSpec.java
@@ -18,6 +18,6 @@ public interface ReportControllerSpec {
     @PostMapping("/register")
     ApiResponse<Boolean> registerReport(
             @Parameter(description = "피싱 신고 정보") @RequestBody PhishingReportUpsertRequest request,
-            @Parameter(description = "사용자 ID") @LoginUser Long userId
+            @LoginUser Long userId
     );
 }

--- a/qrust-common/src/main/java/com/qrust/exception/report/ErrorMessages.java
+++ b/qrust-common/src/main/java/com/qrust/exception/report/ErrorMessages.java
@@ -1,0 +1,6 @@
+package com.qrust.exception.report;
+
+public class ErrorMessages {
+    public static final String REPORT_URL_NOT_EXIST = "존재하지 않는 url입니다.";
+
+}

--- a/qrust-common/src/main/java/com/qrust/exception/report/ErrorMessages.java
+++ b/qrust-common/src/main/java/com/qrust/exception/report/ErrorMessages.java
@@ -2,5 +2,7 @@ package com.qrust.exception.report;
 
 public class ErrorMessages {
     public static final String REPORT_URL_NOT_EXIST = "존재하지 않는 url입니다.";
+    public static final String REPORT_ALREADY_PROCESSED = "신고는 이미 처리된 상태입니다.";
 
+    public static final String REPORT_NOT_EXIST = "신고를 찾을 수 없습니다.";
 }

--- a/qrust-common/src/main/java/com/qrust/exception/report/ErrorMessages.java
+++ b/qrust-common/src/main/java/com/qrust/exception/report/ErrorMessages.java
@@ -3,6 +3,5 @@ package com.qrust.exception.report;
 public class ErrorMessages {
     public static final String REPORT_URL_NOT_EXIST = "존재하지 않는 url입니다.";
     public static final String REPORT_ALREADY_PROCESSED = "신고는 이미 처리된 상태입니다.";
-
     public static final String REPORT_NOT_EXIST = "신고를 찾을 수 없습니다.";
 }

--- a/qrust-common/src/main/java/com/qrust/exception/user/ErrorMessages.java
+++ b/qrust-common/src/main/java/com/qrust/exception/user/ErrorMessages.java
@@ -3,6 +3,8 @@ package com.qrust.exception.user;
 public class ErrorMessages {
 
     public static final String USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
-
     public static final String PASSWORD_NOT_FOUND = "패스워드를 찾을 수 없습니다.";
+    public static final String USER_INVALID_ROLE = "유효하지 않은 User Role";
+    public static final String USER_NOT_AUTHORIZED = "인증되지 않은 사용자";
+
 }

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -15,9 +15,9 @@ public class ReportFacade {
     private final ReportUrlService reportUrlService;
 
     @Transactional
-    public void upsertReport(PhishingReportUpsertRequest request) {
+    public void upsertReport(PhishingReportUpsertRequest request, Long userId) {
         ReportUrl reportUrl = reportUrlService.upsert(request.url());
         reportUrlService.increaseReportCount(request.url());
-        phishingReportService.save(request, reportUrl);
+        phishingReportService.save(request, reportUrl, userId);
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -4,7 +4,9 @@ import com.qrust.report.domain.entity.PhishingReport;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.service.PhishingReportService;
 import com.qrust.report.domain.service.ReportUrlService;
+import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,12 @@ public class ReportFacade {
         ReportUrl reportUrl = reportUrlService.upsert(request.url());
         phishingReportService.save(request, reportUrl, userId);
     }
+
+    @Transactional(readOnly = true)
+    public List<PhishingReportResponse> getMyReports(Long userId) {
+        return phishingReportService.getMyReports(userId);
+    }
+
 
     @Transactional
     public void approveReport(Long reportId) {

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -1,5 +1,6 @@
 package com.qrust.report.application;
 
+import com.qrust.report.domain.entity.PhishingReport;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.service.PhishingReportService;
 import com.qrust.report.domain.service.ReportUrlService;
@@ -17,13 +18,13 @@ public class ReportFacade {
     @Transactional
     public void registerReport(PhishingReportUpsertRequest request, Long userId) {
         ReportUrl reportUrl = reportUrlService.upsert(request.url());
-        reportUrlService.increaseReportCount(request.url());
         phishingReportService.save(request, reportUrl, userId);
     }
 
     @Transactional
     public void approveReport(Long reportId) {
-        phishingReportService.approveReport(reportId);
+        PhishingReport report = phishingReportService.approveReport(reportId);
+        reportUrlService.increaseReportCount(report.getReportUrl().getUrl());
     }
 
     @Transactional

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -4,6 +4,7 @@ import com.qrust.report.domain.entity.PhishingReport;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.service.PhishingReportService;
 import com.qrust.report.domain.service.ReportUrlService;
+import com.qrust.report.dto.PhishingReportDetailResponse;
 import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
 import java.util.List;
@@ -28,6 +29,10 @@ public class ReportFacade {
         return phishingReportService.getMyReports(userId);
     }
 
+    @Transactional(readOnly = true)
+    public PhishingReportDetailResponse getReportDetail(Long reportId, Long userId) {
+        return phishingReportService.getReportDetail(reportId, userId);
+    }
 
     @Transactional
     public void approveReport(Long reportId) {

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -20,4 +20,14 @@ public class ReportFacade {
         reportUrlService.increaseReportCount(request.url());
         phishingReportService.save(request, reportUrl, userId);
     }
+
+    @Transactional
+    public void approveReport(Long reportId) {
+        phishingReportService.approveReport(reportId);
+    }
+
+    @Transactional
+    public void rejectReport(Long reportId) {
+        phishingReportService.rejectReport(reportId);
+    }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -15,7 +15,7 @@ public class ReportFacade {
     private final ReportUrlService reportUrlService;
 
     @Transactional
-    public void upsertReport(PhishingReportUpsertRequest request, Long userId) {
+    public void registerReport(PhishingReportUpsertRequest request, Long userId) {
         ReportUrl reportUrl = reportUrlService.upsert(request.url());
         reportUrlService.increaseReportCount(request.url());
         phishingReportService.save(request, reportUrl, userId);

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -1,0 +1,23 @@
+package com.qrust.report.application;
+
+import com.qrust.report.domain.entity.ReportUrl;
+import com.qrust.report.domain.service.PhishingReportService;
+import com.qrust.report.domain.service.ReportUrlService;
+import com.qrust.report.dto.PhishingReportRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ReportFacade {
+    private final PhishingReportService phishingReportService;
+    private final ReportUrlService reportUrlService;
+
+    @Transactional
+    public void upsertReport(PhishingReportRequest request) {
+        ReportUrl reportUrl = reportUrlService.upsert(request.url());
+        reportUrlService.increaseReportCount(request.url());
+        phishingReportService.save(request, reportUrl);
+    }
+}

--- a/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
+++ b/qrust-domain/src/main/java/com/qrust/report/application/ReportFacade.java
@@ -3,7 +3,7 @@ package com.qrust.report.application;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.service.PhishingReportService;
 import com.qrust.report.domain.service.ReportUrlService;
-import com.qrust.report.dto.PhishingReportRequest;
+import com.qrust.report.dto.PhishingReportUpsertRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +15,7 @@ public class ReportFacade {
     private final ReportUrlService reportUrlService;
 
     @Transactional
-    public void upsertReport(PhishingReportRequest request) {
+    public void upsertReport(PhishingReportUpsertRequest request) {
         ReportUrl reportUrl = reportUrlService.upsert(request.url());
         reportUrlService.increaseReportCount(request.url());
         phishingReportService.save(request, reportUrl);

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
@@ -3,6 +3,7 @@ package com.qrust.report.domain.entity;
 import com.qrust.common.infrastructure.jpa.shared.BaseEntity;
 import com.qrust.report.domain.entity.vo.ApproveType;
 import com.qrust.report.domain.entity.vo.ReportType;
+import com.qrust.report.dto.PhishingReportRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -53,4 +54,15 @@ public class PhishingReport extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "approve_type", nullable = false)
     private ApproveType approveType;
+
+    public static PhishingReport of(PhishingReportRequest request, ReportUrl reportUrl) {
+        return PhishingReport.builder()
+                .userId(request.userId())
+                .reportUrl(reportUrl)
+                .reportType(request.reportType())
+                .reportText(request.reportText())
+                .incidentDate(request.incidentDate())
+                .approveType(ApproveType.PENDING)
+                .build();
+    }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
@@ -1,6 +1,10 @@
 package com.qrust.report.domain.entity;
 
+import static com.qrust.exception.error.ErrorCode.INVALID_INPUT_VALUE;
+import static com.qrust.exception.report.ErrorMessages.REPORT_ALREADY_PROCESSED;
+
 import com.qrust.common.infrastructure.jpa.shared.BaseEntity;
+import com.qrust.exception.CustomException;
 import com.qrust.report.domain.entity.vo.ApproveType;
 import com.qrust.report.domain.entity.vo.ReportType;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
@@ -64,5 +68,19 @@ public class PhishingReport extends BaseEntity {
                 .incidentDate(request.incidentDate())
                 .approveType(ApproveType.PENDING)
                 .build();
+    }
+
+    public void approve() {
+        if (this.approveType != ApproveType.PENDING) {
+            throw new CustomException(INVALID_INPUT_VALUE, REPORT_ALREADY_PROCESSED);
+        }
+        this.approveType = ApproveType.APPROVED;
+    }
+
+    public void reject() {
+        if (this.approveType != ApproveType.PENDING) {
+            throw new CustomException(INVALID_INPUT_VALUE, REPORT_ALREADY_PROCESSED);
+        }
+        this.approveType = ApproveType.REJECTED;
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -42,6 +43,9 @@ public class PhishingReport extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "report_type", nullable = false)
     private ReportType reportType;
+
+    @Column(name = "incident_date", nullable = false)
+    private LocalDate incidentDate;
 
     @Column(name = "report_text", nullable = false)
     private String reportText;

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/PhishingReport.java
@@ -3,7 +3,7 @@ package com.qrust.report.domain.entity;
 import com.qrust.common.infrastructure.jpa.shared.BaseEntity;
 import com.qrust.report.domain.entity.vo.ApproveType;
 import com.qrust.report.domain.entity.vo.ReportType;
-import com.qrust.report.dto.PhishingReportRequest;
+import com.qrust.report.dto.PhishingReportUpsertRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -55,9 +55,9 @@ public class PhishingReport extends BaseEntity {
     @Column(name = "approve_type", nullable = false)
     private ApproveType approveType;
 
-    public static PhishingReport of(PhishingReportRequest request, ReportUrl reportUrl) {
+    public static PhishingReport of(PhishingReportUpsertRequest request, ReportUrl reportUrl, Long userId) {
         return PhishingReport.builder()
-                .userId(request.userId())
+                .userId(userId)
                 .reportUrl(reportUrl)
                 .reportType(request.reportType())
                 .reportText(request.reportText())

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,11 +26,14 @@ public class ReportUrl extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "url_address", nullable = false,  unique = true)
+    @Column(name = "url_address", nullable = false, unique = true)
     private String url;
 
     @Column(name = "report_count", nullable = false)
     private int reportCount;
+
+    @Version
+    private Long version;
 
     public void incrementReportCount() {
         this.reportCount++;

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
@@ -30,4 +30,15 @@ public class ReportUrl extends BaseEntity {
 
     @Column(name = "report_count", nullable = false)
     private int reportCount;
+
+    public void incrementReportCount() {
+        this.reportCount++;
+    }
+
+    public static ReportUrl from(String url) {
+        return ReportUrl.builder()
+                .url(url)
+                .reportCount(1)
+                .build();
+    }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
@@ -25,7 +25,7 @@ public class ReportUrl extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "url_address", nullable = false)
+    @Column(name = "url_address", nullable = false,  unique = true)
     private String url;
 
     @Column(name = "report_count", nullable = false)

--- a/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/entity/ReportUrl.java
@@ -38,7 +38,7 @@ public class ReportUrl extends BaseEntity {
     public static ReportUrl from(String url) {
         return ReportUrl.builder()
                 .url(url)
-                .reportCount(1)
+                .reportCount(0)
                 .build();
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/repository/PhishingReportRepository.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/repository/PhishingReportRepository.java
@@ -2,8 +2,11 @@ package com.qrust.report.domain.repository;
 
 import com.qrust.report.domain.entity.PhishingReport;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PhishingReportRepository extends JpaRepository<PhishingReport, Long> {
     List<PhishingReport> findAllByUserId(Long userId);
+
+    Optional<PhishingReport> findByIdAndUserId(Long id, Long userId);
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/repository/PhishingReportRepository.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/repository/PhishingReportRepository.java
@@ -1,7 +1,9 @@
 package com.qrust.report.domain.repository;
 
 import com.qrust.report.domain.entity.PhishingReport;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PhishingReportRepository extends JpaRepository<PhishingReport, Long> {
+    List<PhishingReport> findAllByUserId(Long userId);
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/repository/ReportUrlRepository.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/repository/ReportUrlRepository.java
@@ -1,7 +1,9 @@
 package com.qrust.report.domain.repository;
 
 import com.qrust.report.domain.entity.ReportUrl;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportUrlRepository extends JpaRepository<ReportUrl, Long> {
+    Optional<ReportUrl> findByUrl(String url);
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
@@ -7,7 +7,9 @@ import com.qrust.exception.CustomException;
 import com.qrust.report.domain.entity.PhishingReport;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.repository.PhishingReportRepository;
+import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,20 @@ public class PhishingReportService {
         PhishingReport report = PhishingReport.of(request, reportUrl, userId);
         phishingReportRepository.save(report);
     }
+
+    @Transactional(readOnly = true)
+    public List<PhishingReportResponse> getMyReports(Long userId) {
+        return phishingReportRepository.findAllByUserId(userId).stream()
+                .map(report -> PhishingReportResponse.builder()
+                        .id(report.getId())
+                        .reportType(report.getReportType())
+                        .url(report.getReportUrl().getUrl())
+                        .approveType(report.getApproveType())
+                        .incidentDate(report.getIncidentDate())
+                        .build())
+                .toList();
+    }
+
 
     @Transactional
     public PhishingReport approveReport(Long reportId) {

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
@@ -3,7 +3,7 @@ package com.qrust.report.domain.service;
 import com.qrust.report.domain.entity.PhishingReport;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.repository.PhishingReportRepository;
-import com.qrust.report.dto.PhishingReportRequest;
+import com.qrust.report.dto.PhishingReportUpsertRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +14,7 @@ public class PhishingReportService {
     private final PhishingReportRepository phishingReportRepository;
 
     @Transactional
-    public void save(PhishingReportRequest request, ReportUrl reportUrl){
+    public void save(PhishingReportUpsertRequest request, ReportUrl reportUrl) {
         PhishingReport report = PhishingReport.of(request, reportUrl);
         phishingReportRepository.save(report);
     }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
@@ -25,15 +25,16 @@ public class PhishingReportService {
     }
 
     @Transactional
-    public void approveReport(Long reportId) {
+    public PhishingReport approveReport(Long reportId) {
         PhishingReport report = getById(reportId);
         report.approve();
+        return report;
     }
 
     @Transactional
     public void rejectReport(Long reportId) {
         PhishingReport report = getById(reportId);
-        report.approve();
+        report.reject();
     }
 
     @Transactional(readOnly = true)

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
@@ -1,12 +1,17 @@
 package com.qrust.report.domain.service;
 
+import static com.qrust.exception.error.ErrorCode.INVALID_INPUT_VALUE;
+import static com.qrust.exception.report.ErrorMessages.REPORT_NOT_EXIST;
+
+import com.qrust.exception.CustomException;
 import com.qrust.report.domain.entity.PhishingReport;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.repository.PhishingReportRepository;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
-import jakarta.transaction.Transactional;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +22,28 @@ public class PhishingReportService {
     public void save(PhishingReportUpsertRequest request, ReportUrl reportUrl, Long userId) {
         PhishingReport report = PhishingReport.of(request, reportUrl, userId);
         phishingReportRepository.save(report);
+    }
+
+    @Transactional
+    public void approveReport(Long reportId) {
+        PhishingReport report = getById(reportId);
+        report.approve();
+    }
+
+    @Transactional
+    public void rejectReport(Long reportId) {
+        PhishingReport report = getById(reportId);
+        report.approve();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<PhishingReport> findById(Long id) {
+        return phishingReportRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public PhishingReport getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new CustomException(INVALID_INPUT_VALUE, REPORT_NOT_EXIST));
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
@@ -14,8 +14,8 @@ public class PhishingReportService {
     private final PhishingReportRepository phishingReportRepository;
 
     @Transactional
-    public void save(PhishingReportUpsertRequest request, ReportUrl reportUrl) {
-        PhishingReport report = PhishingReport.of(request, reportUrl);
+    public void save(PhishingReportUpsertRequest request, ReportUrl reportUrl, Long userId) {
+        PhishingReport report = PhishingReport.of(request, reportUrl, userId);
         phishingReportRepository.save(report);
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
@@ -7,6 +7,7 @@ import com.qrust.exception.CustomException;
 import com.qrust.report.domain.entity.PhishingReport;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.repository.PhishingReportRepository;
+import com.qrust.report.dto.PhishingReportDetailResponse;
 import com.qrust.report.dto.PhishingReportResponse;
 import com.qrust.report.dto.PhishingReportUpsertRequest;
 import java.util.List;
@@ -39,6 +40,20 @@ public class PhishingReportService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public PhishingReportDetailResponse getReportDetail(Long reportId, Long userId) {
+        PhishingReport report = phishingReportRepository.findByIdAndUserId(reportId, userId)
+                .orElseThrow(() -> new CustomException(INVALID_INPUT_VALUE, REPORT_NOT_EXIST));
+
+        return PhishingReportDetailResponse.builder()
+                .id(report.getId())
+                .url(report.getReportUrl().getUrl())
+                .reportType(report.getReportType())
+                .reportText(report.getReportText())
+                .incidentDate(report.getIncidentDate())
+                .approveType(report.getApproveType())
+                .build();
+    }
 
     @Transactional
     public PhishingReport approveReport(Long reportId) {

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/PhishingReportService.java
@@ -1,0 +1,21 @@
+package com.qrust.report.domain.service;
+
+import com.qrust.report.domain.entity.PhishingReport;
+import com.qrust.report.domain.entity.ReportUrl;
+import com.qrust.report.domain.repository.PhishingReportRepository;
+import com.qrust.report.dto.PhishingReportRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PhishingReportService {
+    private final PhishingReportRepository phishingReportRepository;
+
+    @Transactional
+    public void save(PhishingReportRequest request, ReportUrl reportUrl){
+        PhishingReport report = PhishingReport.of(request, reportUrl);
+        phishingReportRepository.save(report);
+    }
+}

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/ReportUrlService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/ReportUrlService.java
@@ -1,0 +1,43 @@
+package com.qrust.report.domain.service;
+
+import static com.qrust.exception.error.ErrorCode.INVALID_INPUT_VALUE;
+import static com.qrust.exception.report.ErrorMessages.REPORT_URL_NOT_EXIST;
+
+import com.qrust.exception.CustomException;
+import com.qrust.exception.error.ErrorCode;
+import com.qrust.report.domain.entity.ReportUrl;
+import com.qrust.report.domain.repository.ReportUrlRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportUrlService {
+    private final ReportUrlRepository reportUrlRepository;
+
+    @Transactional
+    public ReportUrl upsert(String url) {
+        return findByUrl(url)
+                .orElseGet(() -> reportUrlRepository.save(ReportUrl.from(url)));
+    }
+
+    @Transactional
+    public void increaseReportCount(String url) {
+        ReportUrl reportUrl = getByUrl(url);
+        reportUrl.incrementReportCount();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ReportUrl> findByUrl(String url) {
+        return reportUrlRepository.findByUrl(url);
+    }
+
+    @Transactional(readOnly = true)
+    public ReportUrl getByUrl(String url) {
+        return findByUrl(url)
+                .orElseThrow(() -> new CustomException(INVALID_INPUT_VALUE, REPORT_URL_NOT_EXIST));
+    }
+}

--- a/qrust-domain/src/main/java/com/qrust/report/domain/service/ReportUrlService.java
+++ b/qrust-domain/src/main/java/com/qrust/report/domain/service/ReportUrlService.java
@@ -4,10 +4,8 @@ import static com.qrust.exception.error.ErrorCode.INVALID_INPUT_VALUE;
 import static com.qrust.exception.report.ErrorMessages.REPORT_URL_NOT_EXIST;
 
 import com.qrust.exception.CustomException;
-import com.qrust.exception.error.ErrorCode;
 import com.qrust.report.domain.entity.ReportUrl;
 import com.qrust.report.domain.repository.ReportUrlRepository;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportDetailResponse.java
+++ b/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportDetailResponse.java
@@ -1,0 +1,17 @@
+package com.qrust.report.dto;
+
+import com.qrust.report.domain.entity.vo.ApproveType;
+import com.qrust.report.domain.entity.vo.ReportType;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record PhishingReportDetailResponse(
+        Long id,
+        String url,
+        ReportType reportType,
+        String reportText,
+        LocalDate incidentDate,
+        ApproveType approveType
+) {
+}

--- a/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportRequest.java
+++ b/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportRequest.java
@@ -1,0 +1,13 @@
+package com.qrust.report.dto;
+
+import com.qrust.report.domain.entity.vo.ReportType;
+import java.time.LocalDate;
+
+public record PhishingReportRequest(
+        Long userId,
+        String url,
+        ReportType reportType,
+        LocalDate incidentDate,
+        String reportText
+) {
+}

--- a/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportResponse.java
+++ b/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportResponse.java
@@ -1,0 +1,16 @@
+package com.qrust.report.dto;
+
+import com.qrust.report.domain.entity.vo.ApproveType;
+import com.qrust.report.domain.entity.vo.ReportType;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record PhishingReportResponse(
+        Long id,
+        ReportType reportType,
+        String url,
+        ApproveType approveType,
+        LocalDate incidentDate
+) {
+}

--- a/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportUpsertRequest.java
+++ b/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportUpsertRequest.java
@@ -3,7 +3,7 @@ package com.qrust.report.dto;
 import com.qrust.report.domain.entity.vo.ReportType;
 import java.time.LocalDate;
 
-public record PhishingReportRequest(
+public record PhishingReportUpsertRequest(
         Long userId,
         String url,
         ReportType reportType,

--- a/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportUpsertRequest.java
+++ b/qrust-domain/src/main/java/com/qrust/report/dto/PhishingReportUpsertRequest.java
@@ -4,7 +4,6 @@ import com.qrust.report.domain.entity.vo.ReportType;
 import java.time.LocalDate;
 
 public record PhishingReportUpsertRequest(
-        Long userId,
         String url,
         ReportType reportType,
         LocalDate incidentDate,

--- a/qrust-domain/src/main/java/com/qrust/user/domain/entity/vo/UserRole.java
+++ b/qrust-domain/src/main/java/com/qrust/user/domain/entity/vo/UserRole.java
@@ -1,5 +1,9 @@
 package com.qrust.user.domain.entity.vo;
 
+import static com.qrust.exception.error.ErrorCode.INVALID_INPUT_VALUE;
+import static com.qrust.exception.user.ErrorMessages.USER_INVALID_ROLE;
+
+import com.qrust.exception.CustomException;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
@@ -20,5 +24,13 @@ public enum UserRole {
 
     public static boolean isRoleIncluded(UserRole having, UserRole required) {
         return hierarchy.getOrDefault(having, Collections.emptySet()).contains(required);
+    }
+
+    public static UserRole fromStringOrThrow(String value) {
+        try {
+            return UserRole.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(INVALID_INPUT_VALUE, USER_INVALID_ROLE);
+        }
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/user/domain/entity/vo/UserRole.java
+++ b/qrust-domain/src/main/java/com/qrust/user/domain/entity/vo/UserRole.java
@@ -1,7 +1,24 @@
 package com.qrust.user.domain.entity.vo;
 
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
 public enum UserRole {
     USER,
     BUSINESS,
-    ADMIN
+    ADMIN;
+
+    private static final Map<UserRole, Set<UserRole>> hierarchy = new EnumMap<>(UserRole.class);
+
+    static {
+        hierarchy.put(USER, Set.of(USER));
+        hierarchy.put(BUSINESS, Set.of(USER, BUSINESS));
+        hierarchy.put(ADMIN, Set.of(USER, BUSINESS, ADMIN));
+    }
+
+    public static boolean isRoleIncluded(UserRole having, UserRole required) {
+        return hierarchy.getOrDefault(having, Collections.emptySet()).contains(required);
+    }
 }


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #52

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

## User API
![image](https://github.com/user-attachments/assets/bc3cd4e4-b8e7-4e90-98a3-aad02325c7e5)
![image](https://github.com/user-attachments/assets/a969ef8e-4171-42d6-9e0d-822729c0aaf3)
![image](https://github.com/user-attachments/assets/994fec42-a3b4-41bc-a88e-abc15158eb43)

- 신고 등록 api
- 신고 목록 조회 api
- 신고 상세 조회 api

## Admin API
![image](https://github.com/user-attachments/assets/f7ace08b-1300-4b9b-b450-4b7add94909b)

- 신고 거부 api
- 신고 승인 api

```java
@Target({ElementType.TYPE, ElementType.METHOD})
@Retention(RetentionPolicy.RUNTIME)
@Documented
public @interface RoleOnly {
    UserRole[] value();
}
```

```java
//  RoleOnlyAspect.class
private UserRole getCurrentRole() {
        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
        if (authentication == null) {
            throw new CustomException(INVALID_INPUT_VALUE, INVALID_TOKEN);
        }

        String authority = authentication.getAuthorities().stream()
                .findFirst()
                .map(granted -> granted.getAuthority())
                .orElseThrow(() -> new CustomException(INVALID_INPUT_VALUE, USER_NOT_AUTHORIZED));

        return UserRole.fromStringOrThrow(authority.replace("ROLE_", ""));
    }
```
` jwtAuthenticationFilter`에서 이전에 user role을 security context holder에 저장하였는데, 해당 role을 뽑아내는 aop 클래스를 구성하였습니다.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/fdb0794d-64f4-4c9c-9aff-399f0124ffe8" />

이렇게 aop 어노테이션을 컨트롤러 상단에 달아서 admin 계정만 해당 api에 접근할 수 있도록 설계하였습니다.


## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

### 승인/거부 되기 전 신고 목록
![image](https://github.com/user-attachments/assets/b85163a1-21ec-4de4-9429-a240d0a92e07)

### 승인 후의 상태 변화

### 신고 승인
![image](https://github.com/user-attachments/assets/3d7b1344-1622-4052-a1d7-f478dc86aa00)

### 신고 거부
![image](https://github.com/user-attachments/assets/ea801570-756c-43db-b9b4-c00d4f78f124)

### 승인/거부 후 사용자 신고 목록 조회
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/dd38f7e0-0eb5-4ddd-9e38-6d48c0663680" />

### 신고 상세 조회
![image](https://github.com/user-attachments/assets/a1af8626-f452-49e7-81ba-6c7f59a88f1a)

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text
aop 클래스는 UserRole을 참조하기 때문에 common 모듈에 집어넣을 수가 없었습니다..
일단은 임시 방편으로 api 모듈에 넣었습니다.

추가로 approve한 상태의 report url만 가지고 이제 QR 코드 인식 부분 api를 생성하도록 하겠습니다.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 피싱 신고 등록, 내 신고 목록 조회, 신고 상세 조회, 신고 승인/거절 등 피싱 신고 관련 API가 추가되었습니다.
  - 관리자 전용 신고 승인/거절 API가 도입되어, 관리자가 신고 상태를 변경할 수 있습니다.
  - 신고 등록 시 사고일자, 신고 유형, 신고 내용 등 상세 정보를 입력할 수 있습니다.
  - 신고 URL 중복 관리 및 신고 횟수 집계 기능이 추가되었습니다.

- **접근 제어 및 보안**
  - 사용자 역할 기반 접근 제어가 도입되어, 각 API별로 접근 가능한 권한이 제한됩니다.
  - 역할 계층 구조가 반영되어 상위 역할이 하위 역할 권한을 포함하도록 개선되었습니다.

- **오류 메시지 표준화**
  - 신고 및 사용자 인증 관련 오류 메시지가 표준화되어 보다 명확한 안내가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->