### PR TITLE
feat: 큐알 목록 페이징 조회 시 현재 상태 필드 반환 추가

### DIFF
--- a/qrust-api/src/test/java/com/qrust/qrcode/application/QrCodeQueryServiceTest.java
+++ b/qrust-api/src/test/java/com/qrust/qrcode/application/QrCodeQueryServiceTest.java
@@ -99,7 +99,8 @@ class QrCodeQueryServiceTest {
                 "https://cdn.qrust.com/qr.png",
                 "테스트 결과",
                 LocalDate.of(2025, 3, 20),
-                "https://example.com"
+                "https://example.com",
+                QrCodeStatus.ACTIVE
         );
 
         when(qrCodeQueryRepository.searchQrCode(dto, pageable))

--- a/qrust-domain/src/main/java/com/qrust/qrcode/application/QrCodeQueryService.java
+++ b/qrust-domain/src/main/java/com/qrust/qrcode/application/QrCodeQueryService.java
@@ -33,7 +33,8 @@ public class QrCodeQueryService {
                         qrCode.getQrCodeImage().getImageUrl(),
                         qrCode.getQrCodeData().getTitle(),
                         qrCode.getCreatedAt().toLocalDate(),
-                        qrCode.getQrCodeData().getUrl()
+                        qrCode.getQrCodeData().getUrl(),
+                        qrCode.getQrCodeStatus()
                 ));
         return PageResponse.from(result);
     }

--- a/qrust-domain/src/main/java/com/qrust/qrcode/dto/response/QrCodeListResponseDto.java
+++ b/qrust-domain/src/main/java/com/qrust/qrcode/dto/response/QrCodeListResponseDto.java
@@ -1,12 +1,13 @@
 package com.qrust.qrcode.dto.response;
 
+import com.qrust.qrcode.domain.entity.vo.QrCodeStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-public record QrCodeListResponseDto (Long qrCodeId, String qrCodeImageUrl, String title, LocalDate createdAt, String url) {
+public record QrCodeListResponseDto (Long qrCodeId, String qrCodeImageUrl, String title, LocalDate createdAt, String url, QrCodeStatus status) {
 
-    public QrCodeListResponseDto(Long qrCodeId, String qrCodeImageUrl, String title, LocalDateTime createdAt, String url) {
-        this(qrCodeId, qrCodeImageUrl, title, createdAt.toLocalDate(), url);
+    public QrCodeListResponseDto(Long qrCodeId, String qrCodeImageUrl, String title, LocalDateTime createdAt, String url, QrCodeStatus status) {
+        this(qrCodeId, qrCodeImageUrl, title, createdAt.toLocalDate(), url, status);
 
     }
 


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #70

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.
큐알 목록 조회에 현재 상태 필드 반환 추가

페이지에 포함된 큐알 코드 목록에 상태가 EXPIRED인 큐알 코드인 부분은 색상 처리를 따로 하면 좋을 것 같아서 페이징 조회 시 상태 값 필드도 추가되도록 변경했습니다.
```text
feat: 큐알 목록 조회에 현재 상태 필드 반환 추가
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - QR 코드 목록 조회 시 각 QR 코드의 상태 정보가 추가로 표시됩니다.

- **버그 수정**
  - 테스트 코드가 QR 코드 상태 필드를 반영하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->