### PR TITLE
infra: Nginx 와 HTTPS 프로토콜 요청 포워딩 추가

### DIFF
--- a/qrust-api/src/main/java/com/qrust/HealthCheckController.java
+++ b/qrust-api/src/main/java/com/qrust/HealthCheckController.java
@@ -1,0 +1,14 @@
+package com.qrust;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health")
+    public String healthCheck() {
+        return "OK";
+    }
+}

--- a/qrust-domain/src/main/java/com/qrust/common/config/SecurityConfig.java
+++ b/qrust-domain/src/main/java/com/qrust/common/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:3000"));
+        config.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:3000", "http://mayfifth99.store", "https://mayfifth99.store"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
+++ b/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
@@ -1,13 +1,10 @@
 package com.qrust.common.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
+
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -18,21 +15,13 @@ public class SwaggerConfig {
                 .builder()
                 .group("capstone")
                 .pathsToMatch("/**")
-                .build();
-    }
-
-    @Bean
-    public OpenAPI customOpenAPI() {
-        return new OpenAPI()
-                .info(new Info()
-                        .title("QRust API")
-                        .description("QRust API")
-                        .version("1.0.0")
+                .addOpenApiCustomizer(openApi ->
+                        openApi.setInfo(new Info()
+                                .title("qrust api")
+                                .description("QRust API")
+                                .version("1.0.0")
+                        )
                 )
-                .servers(List.of(
-                        new Server().url("https://mayfifth99.store").description("운영 서버"),
-                        new Server().url("http://localhost:8080").description("로컬 서버")
-                ))
-                ;
+                .build();
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
+++ b/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
@@ -26,13 +26,13 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("QRust API")
-                        .description("QRust 프로젝트용 API 문서입니다.")
+                        .description("QRust API")
                         .version("1.0.0")
                 )
                 .servers(List.of(
-                        new Server()
-                                .url("https://localhost:8080")
-                                .description("로컬 테스트용 HTTPS 서버")
-                ));
+                        new Server().url("https://mayfifth99.store").description("운영 서버"),
+                        new Server().url("http://localhost:8080").description("로컬 서버")
+                ))
+                ;
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
+++ b/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
@@ -1,10 +1,13 @@
 package com.qrust.common.config;
 
-
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -15,13 +18,19 @@ public class SwaggerConfig {
                 .builder()
                 .group("capstone")
                 .pathsToMatch("/**")
-                .addOpenApiCustomizer(openApi ->
-                        openApi.setInfo(new Info()
-                                .title("qrust api")
-                                .description("QRust API")
-                                .version("1.0.0")
-                        )
-                )
                 .build();
+    }
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("QRust API")
+                        .description("QRust API")
+                        .version("1.0.0")
+                )
+                .servers(List.of(
+                        new Server().url("https://mayfifth99.store")
+                ));
     }
 }

--- a/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
+++ b/qrust-domain/src/main/java/com/qrust/common/config/SwaggerConfig.java
@@ -26,11 +26,13 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("QRust API")
-                        .description("QRust API")
+                        .description("QRust 프로젝트용 API 문서입니다.")
                         .version("1.0.0")
                 )
                 .servers(List.of(
-                        new Server().url("https://mayfifth99.store")
+                        new Server()
+                                .url("https://localhost:8080")
+                                .description("로컬 테스트용 HTTPS 서버")
                 ));
     }
 }


### PR DESCRIPTION

## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #65 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

/etc/nginx/sites-available/deafult

```nginx
# 1. HTTP 요청을 HTTPS로 리디렉션
server {
    listen 80 default_server;
    server_name mayfifth99.store;

    location / {
        return 301 https://$host$request_uri;
    }
}

# 2. HTTPS 요청을 처리하고 백엔드로 프록시
server {
    listen 443 ssl default_server;
    server_name mayfifth99.store;

    ssl_certificate /etc/letsencrypt/live/mayfifth99.store/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/mayfifth99.store/privkey.pem;

    location / {
        proxy_pass http://localhost:8080;
    }
}
```

```text
nginx 설치 후 config 파일에 mayfifth99.store 요청을 localhost:8080 (스프링 애플리케이션)으로 포워딩하는 설정 추가 했습니다.

이제 curl -X 'POST'  'http://mayfifth99.store:8080/api/v1/auth/login'  요청을
curl -X 'POST' https://mayfifth99.store/api/v1/auth/login' 으로 요청하면 정상 동작합니다.



```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

실행 결과

curl -X POST https://mayfifth99.store/api/v1/auth/login   -H "Content-Type: application/json"   -d '{"email": "string", "password": "string"}'
{"success":true,"data":true,"error":null}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 애플리케이션의 상태를 확인할 수 있는 헬스 체크(Health Check) 엔드포인트(/health)가 추가되었습니다.

- **버그 수정**
  - CORS 허용 도메인에 "http://mayfifth99.store"와 "https://mayfifth99.store"가 추가되어, 해당 도메인에서의 접근이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->